### PR TITLE
Add support for specifying label size for UPS

### DIFF
--- a/lib/omniship/carriers/ups.rb
+++ b/lib/omniship/carriers/ups.rb
@@ -339,14 +339,32 @@ module Omniship
                 end
               }
             end
-            xml.LabelSpecification {
-              xml.LabelPrintMethod {
-                xml.Code 'GIF'
-              }
-              xml.LabelImageFormat {
-                xml.Code 'PNG'
-              }
+          }
+
+          xml.LabelSpecification {
+
+            label_specification = options[:label_specification] || {
+              image_format_code: 'GIF',
+              print_method_code: 'GIF',
+              stock_size: {}
             }
+
+            xml.LabelPrintMethod {
+              xml.Code label_specification[:print_method_code]
+            }
+
+            xml.LabelImageFormat {
+              if label_specification[:print_method_code] == 'GIF'
+                xml.Code label_specification[:image_format_code]
+              end
+            }
+
+            if label_specification[:stock_size].values_at(:height, :width).all?
+              xml.LabelStockSize {
+                xml.Height label_specification[:stock_size][:height]
+                xml.Width label_specification[:stock_size][:width]
+              }
+            end
           }
         }
       end


### PR DESCRIPTION
Adds support for customizing label size for UPS carrier:

```ruby

omniship_client = Omniship::UPS::new(credentials)

options = {} # Ignoring other options required

options.merge!({
  label_specification: {
    print_method_code: 'EPL',
    stock_size: {
      height: 4,
      width: 6
    }
  }
})

omniship_client.create_shipment(
  origin,
  destination,
  packages,
  options
)
```

The code above will generate an XML request including:

```xml
<LabelSpecification>
  <PrintMethod>
    <Code>EPL</Code>
  </PrintMethod>
  <StockSize>
    <Height>4</Height>
    <Width>6</Width>
  </StockSize>
</LabelSpecification>

```

And the API response would return an XML document including:

```xml
<LabelImage>
  <LabelImageFormat>
    <Code>EPL</Code>
  </LabelImageFormat> 
  <GraphicImage> # ENCODED IMAGE #</GraphicImage>
</LabelImage>

```