### PR TITLE
[UPS] Ensure all US territories use CompanyName as Address Location attribute

### DIFF
--- a/lib/omniship/carriers/ups.rb
+++ b/lib/omniship/carriers/ups.rb
@@ -195,7 +195,7 @@ module Omniship
     def upsified_location(location)
       if location.country_code == 'US' && US_TERRITORIES_TREATED_AS_COUNTRIES.include?(location.state)
         atts = {:country => location.state}
-        [:zip, :city, :address1, :address2, :address3, :phone, :fax, :address_type, :attention_name].each do |att|
+        [:zip, :city, :address1, :address2, :address3, :phone, :fax, :address_type, :attention_name, :company_name].each do |att|
           atts[att] = location.send(att)
         end
         Address.new(atts)


### PR DESCRIPTION
For any of the US territories treated as countries such as:

> AS, FM, GU, MH, MP, PW, PR, VI

Ensure the Address#company_name is always assigned, as it's used for building ShipConfirm payloads
which require the ShipTo container.